### PR TITLE
Don't assume all jobs are available locally

### DIFF
--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -27,10 +27,14 @@ module Resque
         return false unless Resque.redis.get(rlock)
 
         Resque.working.map {|w| w.job }.map do |item|
-          payload = item['payload']
-          klass = Resque::Job.constantize(payload['class'])
-          args = payload['args']
-          return false if rlock == klass.run_lock(*args)
+          begin
+            payload = item['payload']
+            klass = Resque::Job.constantize(payload['class'])
+            args = payload['args']
+            return false if rlock == klass.run_lock(*args)
+          rescue NameError
+            # unknown job class, ignore
+          end
         end
         true
       end


### PR DESCRIPTION
This assumes all the currently running jobs are defined locally, which may not be the case in an environment where the resque instance is shared: https://github.com/tdtran/resque-uniq/blob/master/lib/resque/plugins/unique_job.rb#L31
