### PR TITLE
Fix autoexpire lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source :rubygems
 
+gemspec
+
 gem "redis"
 gem "resque"
 gem 'yajl-ruby', :require => 'yajl/json_gem'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ You can tell _resque-uniq_ to auto-expire job locks by setting `@unique_lock_aut
 
 Lock autoexpiration was necessary to protect against stale locks. With the new run lock trick you probably don't need it anymore.
 
+If you want to define a default `unique_lock_autoexpire` in the base class and let other jobs to extend that base class
+you cannot use `@unique_lock_autoexpire` since it's not inherited by subclasses. Define a class method with the same
+name instead
+
+    class BaseJob
+      extend Resque::Plugins::UniqueJob
+
+      def self.queue
+        :default_queue
+      end
+
+      def self.unique_lock_autoexpire
+        600 # TTL = 10 minutes
+      end
+    end
+
+    class SmallJob < BaseJob
+      def self.perform
+        ...
+      end
+    end
+
+    class BiglJob < BaseJob
+      def self.unique_lock_autoexpire
+        3 * 3600  # TTL = 3 hours
+      end
+
+      def self.perform
+        ...
+      end
+    end
+
 ## Credits
 
 There are several similar Resque plugins. We tried them all but for one reason or another they didn't work reliably

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -65,6 +65,10 @@ module Resque
         end
       end
 
+      def after_dequeue_lock(*args)
+        Resque.redis.del(run_lock(*args))
+        Resque.redis.del(lock(*args))
+      end
 
       private
 

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -46,8 +46,9 @@ module Resque
           Resque.redis.del "#{RUN_LOCK_NAME_PREFIX}#{lock_name}"
         end
         nx = Resque.redis.setnx(lock_name, Time.now.to_i)
-        if defined?(@unique_lock_autoexpire) && @unique_lock_autoexpire > 0
-          Resque.redis.expire(lock_name, @unique_lock_autoexpire)
+        ttl = instance_variable_get(:@unique_lock_autoexpire) || respond_to?(:unique_lock_autoexpire) && unique_lock_autoexpire
+        if ttl && ttl > 0
+          Resque.redis.expire(lock_name, ttl)
         end
         nx
       end


### PR DESCRIPTION
I didn't realize class variables are not inherited in Ruby. If one set @unique_lock_autoexpire in the base class, that setting does not have any effect in the subclasses.

This pull request allows users to set lock autoexpiration using class method `unique_lock_autoexpire`
