### PR TITLE
Delete job locks after kill -9

### DIFF
--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -62,14 +62,16 @@ module Resque
         begin
           yield
         ensure
-          Resque.redis.del(rlock)
-          Resque.redis.del(lock(*args))
+          unlock(*args)
         end
       end
 
       def after_dequeue_lock(*args)
-        Resque.redis.del(run_lock(*args))
-        Resque.redis.del(lock(*args))
+        unlock(*args)
+      end
+
+      def on_failure_lock(e, *args)
+        unlock(*args)
       end
 
       private
@@ -90,6 +92,11 @@ module Resque
         else
           obj.to_s
         end
+      end
+
+      def unlock(*args)
+        Resque.redis.del(run_lock(*args))
+        Resque.redis.del(lock(*args))
       end
     end
   end


### PR DESCRIPTION
Hi! Nice plugin. I think I'm going to use it.

However, `resque-uniq` currently relies on `ensure` statement within `around_perform` hook. There are situations when `ensure` block is not executed (for example, when we shutdown a worker with `kill -9` or OOM-killer kills the process etc).

To handle such situations gracefully we can run a simple loop:

``` ruby
loop {
  Resque.workers.each(&:prune_dead_workers)
  sleep 5
}
```

`Resque::Worker#prune_dead_workers` can detect "lost" workers and call `on_failure` callbacks for such jobs and delete corresponding Redis keys.

I've tried to simulate the situation above in tests and written a code to fix it, with a little bit of refactoring. Please take a look at it.

Thanks.
