### PR TITLE
Double check key expiration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -61,7 +61,6 @@ module Resque
         end
         not_exist = Resque.redis.setnx(lock_name, Time.now.to_i)
         if not_exist
-          ttl = instance_variable_get(:@unique_lock_autoexpire) || respond_to?(:unique_lock_autoexpire) && unique_lock_autoexpire
           if ttl && ttl > 0
             Resque.redis.expire(lock_name, ttl)
           end

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -45,7 +45,7 @@ module Resque
 
       def get_lock(lock)
         set_time = Resque.redis.get(lock)
-        if set_time > Time.now.to_i - ttl
+        if ttl && set_time && (set_time > Time.now.to_i - ttl)
           Resque.redis.del(lock)
           nil
         else

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -44,12 +44,13 @@ module Resque
       end
 
       def get_lock(lock)
-        set_time = Resque.redis.get(lock)
+        lock_value = Resque.redis.get(lock)
+        set_time = lock_value.to_i
         if ttl && set_time && (set_time > Time.now.to_i - ttl)
           Resque.redis.del(lock)
           nil
         else
-          set_time
+          lock_value
         end
       end
 
@@ -57,7 +58,7 @@ module Resque
         lock_name = lock(*args)
         if stale_lock? lock_name
           Resque.redis.del lock_name
-          Resque.redis.del run_lock_from_lock(lock)
+          Resque.redis.del run_lock_from_lock(lock_name)
         end
         not_exist = Resque.redis.setnx(lock_name, Time.now.to_i)
         if not_exist

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -57,7 +57,7 @@ module Resque
         lock_name = lock(*args)
         if stale_lock? lock_name
           Resque.redis.del lock_name
-          Resque.redis.del "#{RUN_LOCK_NAME_PREFIX}#{lock_name}"
+          Resque.redis.del run_lock_from_lock(lock)
         end
         not_exist = Resque.redis.setnx(lock_name, Time.now.to_i)
         if not_exist


### PR DESCRIPTION
It is possible with the current implementation to create a lock without an expires if the program crashes at the right time. This is a workaround for the potential issue.

It could probably be done more correctly with redis' transactions, but those confuse and scare me.
