### PR TITLE
We must handle the case when job modifies *args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
-- 1.8.7
 - 1.9.3
+- 2.0.0
+- 2.1.0
+services:
+- redis
 notifications:
   email:
     - trung.travis@tdtran.org

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source  'https://rubygems.org'
 
 gemspec
 

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -56,7 +56,9 @@ module Resque
       end
 
       def around_perform_lock(*args)
+        # we must calculate the lock name before executing job's perform method, it can modify *args
         jlock = lock(*args)
+
         rlock = run_lock(*args)
         Resque.redis.set(rlock, Time.now.to_i)
 

--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -56,6 +56,7 @@ module Resque
       end
 
       def around_perform_lock(*args)
+        jlock = lock(*args)
         rlock = run_lock(*args)
         Resque.redis.set(rlock, Time.now.to_i)
 
@@ -63,7 +64,7 @@ module Resque
           yield
         ensure
           Resque.redis.del(rlock)
-          Resque.redis.del(lock(*args))
+          Resque.redis.del(jlock)
         end
       end
 


### PR DESCRIPTION
when it happens the current code gets a wrong redis key and never deletes the right key
