### PR TITLE
fix two bugs in the code and two bugs in the tests

### DIFF
--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -46,7 +46,7 @@ module Resque
       def get_lock(lock)
         lock_value = Resque.redis.get(lock)
         set_time = lock_value.to_i
-        if ttl && set_time && (set_time > Time.now.to_i - ttl)
+        if ttl && lock_value && (set_time < Time.now.to_i - ttl)
           Resque.redis.del(lock)
           nil
         else

--- a/test/unique_job_test.rb
+++ b/test/unique_job_test.rb
@@ -26,9 +26,7 @@ class UniqueJobTest < Test::Unit::TestCase
   class ExtendedAutoExpireLockJob < AutoexpireLockJobBase ; end
 
   def setup
-    Resque.remove_queue(Resque.queue_from_class(Job))
-    Resque.remove_queue(Resque.queue_from_class(AutoexpireLockJob))
-    Resque.redis.keys('*:UniqueJobTest::*').each {|k| Resque.redis.del(k) }
+    Resque.redis.flushdb
   end
 
   def test_no_more_than_one_job_instance
@@ -95,7 +93,7 @@ class UniqueJobTest < Test::Unit::TestCase
   end
 
   def test_cleans_up_old_lock_during_enqueue
-    Resque.redis.set(AutoexpireLockJob.lock(123), Time.now.to_i + 100)
+    Resque.redis.set(AutoexpireLockJob.lock(123), Time.now.to_i - 100)
     Resque.enqueue(AutoexpireLockJob, 123)
     assert_equal 1, Resque.size(Resque.queue_from_class(AutoexpireLockJob))
   end


### PR DESCRIPTION
- set_time = lock_value.to_i, so it will never be not true, use
  lock_value in the conditional
- We want set_time to be less than current time - ttl, not more than
- make sure to delete old locks in setup
- if we want a lock to be expired it should be pushed into the past, not
  the future
