### PR TITLE
Time marshalling is incorrect

### DIFF
--- a/lib/resque/plugins/unique_job.rb
+++ b/lib/resque/plugins/unique_job.rb
@@ -127,10 +127,8 @@ module Resque
           s = []
           obj.each { |a| s << obj_to_string(a) }
           s.to_s
-        when Time
-          obj.to_i
         else
-          obj.to_s
+          Resque.encode(obj)
         end
       end
     end


### PR DESCRIPTION
https://github.com/tdtran/resque-uniq/pull/14 is broken but has exposed the root cause of the problem.

JsonEncoder is doing the marshalling in resque but it doesn't handle Time objects correctly (the sender sends a Time object but the reciever gets a String).

This means the lock on the enqueueing side does to_i on the Time but the lock on the performing side uses the string version of the Time.
